### PR TITLE
Fix The httpx command line client could not run because the required …

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfixes
 - Fix `customer_monitoring_level` parameter in `login` method in agent-api v3.3/v3.4/v3.5 classes.
+- Fix `httpx` version in setup.cfg
 
 ### Removed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
          websocket-client==1.2.1
-         httpx ==0.19.0
+         httpx ==0.23.0
 
 [options.extras_require]
 httpx = http2


### PR DESCRIPTION
…dependencies were not installed.

Make sure you've installed everything with: pip install 'httpx[cli]' version in setup.cfg